### PR TITLE
Verify UserId and Tokens Before Accessing Logic

### DIFF
--- a/AccountManager/AccountManager.csproj
+++ b/AccountManager/AccountManager.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.9.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />

--- a/AccountManager/CreateUser.cs
+++ b/AccountManager/CreateUser.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
+using Azure.Data.Tables;
 
 namespace GoRideShare
 {
@@ -83,6 +84,8 @@ namespace GoRideShare
 
                     // Generate the OAuth 2.0 token for logic_layer
                     string logic_token = await jwtTokenHandler.GenerateTokenAsync();
+
+                    await SecurityGuard.SaveUserTokens(userId, logic_token, db_token);
 
                     // Return both OAuth 2.0 tokens, the user_id, and the photo to the client
                     return new OkObjectResult(new

--- a/AccountManager/GoogleLogin.cs
+++ b/AccountManager/GoogleLogin.cs
@@ -98,6 +98,9 @@ namespace GoRideShare
                                                             Environment.GetEnvironmentVariable("OAUTH_SCOPE"));
                 string logicToken = await logicTokenHandler.GenerateTokenAsync();
     
+
+                await SecurityGuard.SaveUserTokens(googleLoginResponse.UserId, logicToken, dbToken);
+
                 // Succeful return
                 return new OkObjectResult(new {
                     User_id = googleLoginResponse.UserId,

--- a/AccountManager/PasswordLogin.cs
+++ b/AccountManager/PasswordLogin.cs
@@ -91,6 +91,8 @@ namespace GoRideShare
                     // Generate the OAuth 2.0 token for logic_layer
                     string logic_token = await jwtTokenHandler.GenerateTokenAsync();
 
+                    await SecurityGuard.SaveUserTokens(userId, logic_token, db_token);
+
                     // Return both OAuth 2.0 tokens, the user_id, and the photo to the client
                     return new OkObjectResult(new
                     {

--- a/AccountManager/SecurityGuard.cs
+++ b/AccountManager/SecurityGuard.cs
@@ -1,4 +1,3 @@
-using System.Reflection.Metadata;
 using Azure;
 using Azure.Data.Tables;
 
@@ -25,7 +24,7 @@ public class SecurityGuard
         {
             // Find the older token set and update it
             TableEntity oldestEntity = userTokensSets[0];
-            
+
             if (DateTime.Parse(userTokensSets[1]["Timestamp"].ToString() ?? "") <= DateTime.Parse(userTokensSets[0]["Timestamp"].ToString() ?? ""))
             {
                 oldestEntity = userTokensSets[1];

--- a/AccountManager/SecurityGuard.cs
+++ b/AccountManager/SecurityGuard.cs
@@ -25,8 +25,8 @@ public class SecurityGuard
         {
             // Find the older token set and update it
             TableEntity oldestEntity = userTokensSets[0];
-
-            if (DateTime.Parse(userTokensSets[1]["Timestamp"].ToString()) <= DateTime.Parse(userTokensSets[0]["Timestamp"].ToString()))
+            
+            if (DateTime.Parse(userTokensSets[1]["Timestamp"].ToString() ?? "") <= DateTime.Parse(userTokensSets[0]["Timestamp"].ToString() ?? ""))
             {
                 oldestEntity = userTokensSets[1];
             }

--- a/AccountManager/SecurityGuard.cs
+++ b/AccountManager/SecurityGuard.cs
@@ -1,0 +1,57 @@
+using System.Reflection.Metadata;
+using Azure;
+using Azure.Data.Tables;
+
+namespace GoRideShare;
+public class SecurityGuard
+{
+    static readonly string connectionString = Environment.GetEnvironmentVariable("USER_TOKENS_TABLE_CONNECTION_STRING") ?? "";
+    static readonly string tableName = "UserTokens";
+    
+    public static async Task SaveUserTokens(string userId, string logicToken, string dbToken)
+    {
+        // Get all tokens stored for this user
+        TableClient client = new(connectionString, tableName);
+        string filter = TableClient.CreateQueryFilter($"(PartitionKey eq {userId})");
+        List<TableEntity> userTokensSets = [];
+
+        await foreach (TableEntity tokenSet in client.QueryAsync<TableEntity>(filter))
+        {
+            userTokensSets.Add(tokenSet);
+        }
+
+        // Save the new tokens
+        if (userTokensSets.Count == 2)
+        {
+            // Find the older token set and update it
+            TableEntity oldestEntity = userTokensSets[0];
+
+            if (DateTime.Parse(userTokensSets[1]["Timestamp"].ToString()) <= DateTime.Parse(userTokensSets[0]["Timestamp"].ToString()))
+            {
+                oldestEntity = userTokensSets[1];
+            }
+
+            oldestEntity["LogicToken"] = logicToken;
+            oldestEntity["DbToken"] = dbToken;
+
+            await client.UpdateEntityAsync(oldestEntity, ETag.All, TableUpdateMode.Replace);
+        }
+        else
+        {
+            string newRowKey = "2";
+            if (userTokensSets.Count == 0) 
+            {   
+                // Adding the first token set for this user
+                newRowKey = "1";
+            }
+
+            TableEntity newEntity = new(userId, newRowKey)
+            {
+                {"LogicToken", logicToken },
+                {"DbToken", dbToken}
+            };
+
+            await client.AddEntityAsync(newEntity);
+        }       
+    } // SaveUserTokens
+}

--- a/AccountManager/sample.local.settings.json
+++ b/AccountManager/sample.local.settings.json
@@ -11,6 +11,7 @@
     "OAUTH_SCOPE": "f",
     "OAUTH_SCOPE_DB": "f",
     "OAUTH_TENANT_ID_DB": "f",
-    "OAUTH_TENANT_ID": "f"
+    "OAUTH_TENANT_ID": "f",
+    "USER_TOKENS_TABLE_CONNECTION_STRING": "f"
   }
 }

--- a/Logic.Tests/Messages/CreateConversationTests.cs
+++ b/Logic.Tests/Messages/CreateConversationTests.cs
@@ -11,13 +11,17 @@ namespace GoRideShare.Tests
     {
         private readonly Mock<ILogger<CreateConversation>> _loggerMock;
         private readonly Mock<IHttpRequestHandler> _httpRequestHandlerMock;
+        private readonly Mock<IAzureTableService> _azureTableService;
+        private readonly Utilities _utilities;                      
         private readonly CreateConversation _createConversation;
 
         public CreateConversationTests()
         {
             _loggerMock = new Mock<ILogger<CreateConversation>>();
             _httpRequestHandlerMock = new Mock<IHttpRequestHandler>();
-            _createConversation = new CreateConversation(_loggerMock.Object, _httpRequestHandlerMock.Object);
+            _azureTableService = new Mock<IAzureTableService>();
+            _utilities = new Utilities(_azureTableService.Object);             
+            _createConversation = new CreateConversation(_loggerMock.Object, _httpRequestHandlerMock.Object, _utilities);
         }
 
         [Fact]

--- a/Logic.Tests/Messages/GetConversationsTests.cs
+++ b/Logic.Tests/Messages/GetConversationsTests.cs
@@ -11,13 +11,17 @@ namespace GoRideShare.Tests
     {
         private readonly Mock<ILogger<GetConversations>> _loggerMock;
         private readonly Mock<IHttpRequestHandler> _httpRequestHandlerMock;
+        private readonly Mock<IAzureTableService> _azureTableService;
+        private readonly Utilities _utilities;              
         private readonly GetConversations _getConversations;
 
         public GetConversationsTests()
         {
             _loggerMock = new Mock<ILogger<GetConversations>>();
             _httpRequestHandlerMock = new Mock<IHttpRequestHandler>();
-            _getConversations = new GetConversations(_loggerMock.Object, _httpRequestHandlerMock.Object);
+            _azureTableService = new Mock<IAzureTableService>();
+            _utilities = new Utilities(_azureTableService.Object);               
+            _getConversations = new GetConversations(_loggerMock.Object, _httpRequestHandlerMock.Object, _utilities);
         }
 
         [Fact]

--- a/Logic.Tests/Messages/GetMessagesTests.cs
+++ b/Logic.Tests/Messages/GetMessagesTests.cs
@@ -11,13 +11,17 @@ namespace GoRideShare.Tests
     {
         private readonly Mock<ILogger<GetMessages>> _loggerMock;
         private readonly Mock<IHttpRequestHandler> _httpRequestHandlerMock;
+        private readonly Mock<IAzureTableService> _azureTableService;
+        private readonly Utilities _utilities;        
         private readonly GetMessages _getMessages;
 
         public GetMessagesTests()
         {
             _loggerMock = new Mock<ILogger<GetMessages>>();
             _httpRequestHandlerMock = new Mock<IHttpRequestHandler>();
-            _getMessages = new GetMessages(_loggerMock.Object, _httpRequestHandlerMock.Object);
+            _azureTableService = new Mock<IAzureTableService>();
+            _utilities = new Utilities(_azureTableService.Object);                
+            _getMessages = new GetMessages(_loggerMock.Object, _httpRequestHandlerMock.Object, _utilities);
         }
 
         [Fact]

--- a/Logic.Tests/Messages/PostMessageTests.cs
+++ b/Logic.Tests/Messages/PostMessageTests.cs
@@ -10,13 +10,17 @@ namespace GoRideShare.Tests
     {
         private readonly Mock<ILogger<PostMessage>> _loggerMock;
         private readonly Mock<IHttpRequestHandler> _httpRequestHandlerMock;
+        private readonly Mock<IAzureTableService> _azureTableService;
+        private readonly Utilities _utilities;        
         private readonly PostMessage _postMessage;
 
         public PostMessageTests()
         {
             _loggerMock = new Mock<ILogger<PostMessage>>();
             _httpRequestHandlerMock = new Mock<IHttpRequestHandler>();
-            _postMessage = new PostMessage(_loggerMock.Object, _httpRequestHandlerMock.Object);
+            _azureTableService = new Mock<IAzureTableService>();
+            _utilities = new Utilities(_azureTableService.Object);            
+            _postMessage = new PostMessage(_loggerMock.Object, _httpRequestHandlerMock.Object, _utilities);
         }
 
         [Fact]

--- a/Logic.Tests/Posts/GetPostsTests.cs
+++ b/Logic.Tests/Posts/GetPostsTests.cs
@@ -11,13 +11,17 @@ namespace GoRideShare.Tests
     {
         private readonly Mock<ILogger<GetPosts>> _loggerMock;
         private readonly Mock<IHttpRequestHandler> _httpRequestHandlerMock;
+        private readonly Mock<IAzureTableService> _azureTableService;
+        private readonly Utilities _utilities;
         private readonly GetPosts _getPosts;
 
         public GetPostsTests()
         {
             _loggerMock = new Mock<ILogger<GetPosts>>();
             _httpRequestHandlerMock = new Mock<IHttpRequestHandler>();
-            _getPosts = new GetPosts(_loggerMock.Object, _httpRequestHandlerMock.Object);
+            _azureTableService = new Mock<IAzureTableService>();
+            _utilities = new Utilities(_azureTableService.Object);
+            _getPosts = new GetPosts(_loggerMock.Object, _httpRequestHandlerMock.Object, _utilities);
         }
 
         [Fact]

--- a/Logic.Tests/Posts/SavePostTests.cs
+++ b/Logic.Tests/Posts/SavePostTests.cs
@@ -12,13 +12,17 @@ namespace GoRideShare.Tests
     {
         private readonly Mock<ILogger<SavePost>> _loggerMock;
         private readonly Mock<IHttpRequestHandler> _httpRequestHandlerMock;
+        private readonly Mock<IAzureTableService> _azureTableService;
+        private readonly Utilities _utilities;
         private readonly SavePost _savePost;
 
         public SavePostTests()
         {
             _loggerMock = new Mock<ILogger<SavePost>>();
             _httpRequestHandlerMock = new Mock<IHttpRequestHandler>();
-            _savePost = new SavePost(_loggerMock.Object, _httpRequestHandlerMock.Object);
+            _azureTableService = new Mock<IAzureTableService>();
+            _utilities = new Utilities(_azureTableService.Object);
+            _savePost = new SavePost(_loggerMock.Object, _httpRequestHandlerMock.Object, _utilities);
         }
 
         [Fact]

--- a/Logic.Tests/Users/EditUserTests.cs
+++ b/Logic.Tests/Users/EditUserTests.cs
@@ -15,13 +15,17 @@ namespace GoRideShare.Tests
     {
         private readonly Mock<ILogger<EditUser>> _loggerMock;
         private readonly Mock<IHttpRequestHandler> _httpRequestHandlerMock;
+        private readonly Mock<IAzureTableService> _azureTableService;
+        private readonly Utilities _utilities;
         private readonly EditUser _editUser;
 
         public EditUserTests()
         {
             _loggerMock = new Mock<ILogger<EditUser>>();
             _httpRequestHandlerMock = new Mock<IHttpRequestHandler>();
-            _editUser = new EditUser(_loggerMock.Object, _httpRequestHandlerMock.Object);
+            _azureTableService = new Mock<IAzureTableService>();
+            _utilities = new Utilities(_azureTableService.Object);
+            _editUser = new EditUser(_loggerMock.Object, _httpRequestHandlerMock.Object, _utilities);
         }
 
         [Fact]

--- a/Logic.Tests/Users/GetUserTests.cs
+++ b/Logic.Tests/Users/GetUserTests.cs
@@ -11,13 +11,17 @@ namespace GoRideShare.Tests
     {
         private readonly Mock<ILogger<GetUser>> _loggerMock;
         private readonly Mock<IHttpRequestHandler> _httpRequestHandlerMock;
+        private readonly Mock<IAzureTableService> _azureTableService;
+        private readonly Utilities _utilities;
         private readonly GetUser _getUser;
 
         public GetUserTests()
         {
             _loggerMock = new Mock<ILogger<GetUser>>();
             _httpRequestHandlerMock = new Mock<IHttpRequestHandler>();
-            _getUser = new GetUser(_loggerMock.Object, _httpRequestHandlerMock.Object);
+            _azureTableService = new Mock<IAzureTableService>();
+            _utilities = new Utilities(_azureTableService.Object);
+            _getUser = new GetUser(_loggerMock.Object, _httpRequestHandlerMock.Object, _utilities);
         }
 
         [Fact]

--- a/Logic/Logic.csproj
+++ b/Logic/Logic.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.9.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
@@ -16,12 +17,13 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MySql.Data" Version="9.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.4" />
     <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" >
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Logic/sample.local.settings.json
+++ b/Logic/sample.local.settings.json
@@ -3,6 +3,7 @@
   "Values": {
     "AzureWebJobsStorage": "",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-    "BASE_API_URL": ""
+    "BASE_API_URL": "",
+    "USER_TOKENS_TABLE_CONNECTION_STRING": ""
   }
 }

--- a/Logic/src/Messages/CreateConversation.cs
+++ b/Logic/src/Messages/CreateConversation.cs
@@ -11,10 +11,12 @@ namespace GoRideShare
         private readonly ILogger<CreateConversation> _logger;
         private readonly string? _baseApiUrl;
         private readonly IHttpRequestHandler _httpRequestHandler;
+        private readonly Utilities _utilities;
 
-        public CreateConversation(ILogger<CreateConversation> logger, IHttpRequestHandler httpRequestHandler)
+        public CreateConversation(ILogger<CreateConversation> logger, IHttpRequestHandler httpRequestHandler, Utilities utilities)
         {
             _logger = logger;
+            _utilities = utilities;
             _httpRequestHandler = httpRequestHandler;
             _baseApiUrl = Environment.GetEnvironmentVariable("BASE_API_URL");
         }
@@ -24,7 +26,7 @@ namespace GoRideShare
         public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "Conversations")] HttpRequest req)
         {
             // If validation result is not null, return the bad request result
-            var validationResult = Utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
+            var validationResult = _utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
             if (validationResult != null)
             {
                 return validationResult;

--- a/Logic/src/Messages/CreateConversation.cs
+++ b/Logic/src/Messages/CreateConversation.cs
@@ -24,7 +24,7 @@ namespace GoRideShare
         public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "Conversations")] HttpRequest req)
         {
             // If validation result is not null, return the bad request result
-            var validationResult = Utilities.ValidateHeaders(req.Headers, out string userId, out string db_token);
+            var validationResult = Utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
             if (validationResult != null)
             {
                 return validationResult;

--- a/Logic/src/Messages/GetConversations.cs
+++ b/Logic/src/Messages/GetConversations.cs
@@ -11,10 +11,12 @@ namespace GoRideShare
         private readonly ILogger<GetConversations> _logger;
         private readonly string? _baseApiUrl;
         private readonly IHttpRequestHandler _httpRequestHandler;
+        private readonly Utilities _utilities;
 
-        public GetConversations(ILogger<GetConversations> logger, IHttpRequestHandler httpRequestHandler)
+        public GetConversations(ILogger<GetConversations> logger, IHttpRequestHandler httpRequestHandler, Utilities utilities)
         {
             _logger = logger;
+            _utilities = utilities;
             _httpRequestHandler = httpRequestHandler;
             _baseApiUrl = Environment.GetEnvironmentVariable("BASE_API_URL");
         }
@@ -24,7 +26,7 @@ namespace GoRideShare
         public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "Conversations")] HttpRequest req)
         {
             // If validation result is not null, return the bad request result
-            var validationResult = Utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
+            var validationResult = _utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
             if (validationResult != null)
             {
                 return validationResult;

--- a/Logic/src/Messages/GetConversations.cs
+++ b/Logic/src/Messages/GetConversations.cs
@@ -24,7 +24,7 @@ namespace GoRideShare
         public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "Conversations")] HttpRequest req)
         {
             // If validation result is not null, return the bad request result
-            var validationResult = Utilities.ValidateHeaders(req.Headers, out string userId, out string db_token);
+            var validationResult = Utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
             if (validationResult != null)
             {
                 return validationResult;

--- a/Logic/src/Messages/GetMessages.cs
+++ b/Logic/src/Messages/GetMessages.cs
@@ -11,10 +11,12 @@ namespace GoRideShare
         private readonly ILogger<GetMessages> _logger;
         private readonly string? _baseApiUrl;
         private readonly IHttpRequestHandler _httpRequestHandler;
+        private readonly Utilities _utilities;
 
-        public GetMessages(ILogger<GetMessages> logger, IHttpRequestHandler httpRequestHandler)
+        public GetMessages(ILogger<GetMessages> logger, IHttpRequestHandler httpRequestHandler, Utilities utilities)
         {
             _logger = logger;
+            _utilities = utilities;
             _httpRequestHandler = httpRequestHandler;
             _baseApiUrl = Environment.GetEnvironmentVariable("BASE_API_URL");
         }
@@ -24,7 +26,7 @@ namespace GoRideShare
         public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "Messages/{conversation_id}")] HttpRequest req, string conversation_id)
         {
             // If validation result is not null, return the bad request result
-            var validationResult = Utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
+            var validationResult = _utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
             if (validationResult != null)
             {
                 return validationResult;

--- a/Logic/src/Messages/GetMessages.cs
+++ b/Logic/src/Messages/GetMessages.cs
@@ -24,7 +24,7 @@ namespace GoRideShare
         public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "Messages/{conversation_id}")] HttpRequest req, string conversation_id)
         {
             // If validation result is not null, return the bad request result
-            var validationResult = Utilities.ValidateHeaders(req.Headers, out string userId, out string db_token);
+            var validationResult = Utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
             if (validationResult != null)
             {
                 return validationResult;

--- a/Logic/src/Messages/PostMessage.cs
+++ b/Logic/src/Messages/PostMessage.cs
@@ -11,10 +11,12 @@ namespace GoRideShare
         private readonly ILogger<PostMessage> _logger;
         private readonly string? _baseApiUrl;
         private readonly IHttpRequestHandler _httpRequestHandler;
+        private readonly Utilities _utilities;
 
-        public PostMessage(ILogger<PostMessage> logger, IHttpRequestHandler httpRequestHandler)
+        public PostMessage(ILogger<PostMessage> logger, IHttpRequestHandler httpRequestHandler, Utilities utilities)
         {
             _logger = logger;
+            _utilities = utilities;
             _httpRequestHandler = httpRequestHandler;
             _baseApiUrl = Environment.GetEnvironmentVariable("BASE_API_URL");
         }
@@ -24,7 +26,7 @@ namespace GoRideShare
         public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "Messages")] HttpRequest req)
         {
             // If validation result is not null, return the bad request result
-            var validationResult = Utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
+            var validationResult = _utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
             if (validationResult != null)
             {
                 return validationResult;

--- a/Logic/src/Messages/PostMessage.cs
+++ b/Logic/src/Messages/PostMessage.cs
@@ -24,7 +24,7 @@ namespace GoRideShare
         public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "Messages")] HttpRequest req)
         {
             // If validation result is not null, return the bad request result
-            var validationResult = Utilities.ValidateHeaders(req.Headers, out string userId, out string db_token);
+            var validationResult = Utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
             if (validationResult != null)
             {
                 return validationResult;

--- a/Logic/src/Posts/GetPosts.cs
+++ b/Logic/src/Posts/GetPosts.cs
@@ -13,10 +13,12 @@ namespace GoRideShare
         private readonly ILogger<GetPosts> _logger;
         private readonly IHttpRequestHandler _httpRequestHandler;
         private readonly string? _baseApiUrl;
+        private readonly Utilities _utilities;
 
-        public GetPosts(ILogger<GetPosts> logger, IHttpRequestHandler httpRequestHandler)
+        public GetPosts(ILogger<GetPosts> logger, IHttpRequestHandler httpRequestHandler, Utilities utilities)
         {
             _logger = logger;
+            _utilities = utilities;
             _httpRequestHandler = httpRequestHandler;
             _baseApiUrl = Environment.GetEnvironmentVariable("BASE_API_URL");
         }
@@ -26,7 +28,7 @@ namespace GoRideShare
         public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "Posts/{user_id}")] HttpRequest req, string user_id)
         {
             // If validation result is not null, return the bad request result
-            var validationResult = Utilities.ValidateHeadersAndTokens(req.Headers, out string requsterUserId, out string db_token);
+            var validationResult = _utilities.ValidateHeadersAndTokens(req.Headers, out string requsterUserId, out string db_token);
             if (validationResult != null)
             {
                 return validationResult;

--- a/Logic/src/Posts/GetPosts.cs
+++ b/Logic/src/Posts/GetPosts.cs
@@ -26,7 +26,7 @@ namespace GoRideShare
         public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "Posts/{user_id}")] HttpRequest req, string user_id)
         {
             // If validation result is not null, return the bad request result
-            var validationResult = Utilities.ValidateHeaders(req.Headers, out string requsterUserId, out string db_token);
+            var validationResult = Utilities.ValidateHeadersAndTokens(req.Headers, out string requsterUserId, out string db_token);
             if (validationResult != null)
             {
                 return validationResult;

--- a/Logic/src/Posts/SavePost.cs
+++ b/Logic/src/Posts/SavePost.cs
@@ -24,7 +24,7 @@ namespace GoRideShare
         public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "Posts")] HttpRequest req)
         {
             // If validation result is not null, return the bad request result
-            var validationResult = Utilities.ValidateHeaders(req.Headers, out string userId, out string db_token);
+            var validationResult = Utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
             if (validationResult != null)
             {
                 return validationResult;

--- a/Logic/src/Posts/SavePost.cs
+++ b/Logic/src/Posts/SavePost.cs
@@ -11,10 +11,12 @@ namespace GoRideShare
         private readonly ILogger<SavePost> _logger;
         private readonly string? _baseApiUrl;
         private readonly IHttpRequestHandler _httpRequestHandler;
+        private readonly Utilities _utilities;
 
-        public SavePost(ILogger<SavePost> logger, IHttpRequestHandler httpRequestHandler)
+        public SavePost(ILogger<SavePost> logger, IHttpRequestHandler httpRequestHandler, Utilities utilities)
         {
             _logger = logger;
+            _utilities = utilities;
             _httpRequestHandler = httpRequestHandler;
             _baseApiUrl = Environment.GetEnvironmentVariable("BASE_API_URL");
         }
@@ -24,7 +26,7 @@ namespace GoRideShare
         public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "Posts")] HttpRequest req)
         {
             // If validation result is not null, return the bad request result
-            var validationResult = Utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
+            var validationResult = _utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
             if (validationResult != null)
             {
                 return validationResult;

--- a/Logic/src/Shared/AzureTableService.cs
+++ b/Logic/src/Shared/AzureTableService.cs
@@ -1,0 +1,53 @@
+using Microsoft.AspNetCore.Mvc;
+using Azure.Data.Tables;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using System.Net.Http.Headers;
+
+namespace GoRideShare
+{
+    public class AzureTableService : IAzureTableService
+    {
+
+        private static readonly HttpClient _httpClient = new HttpClient();
+
+        public (bool, string) VerifyUserTokens(string logicToken, string userId, string dbToken)
+        {
+            string connectionString = Environment.GetEnvironmentVariable("USER_TOKENS_TABLE_CONNECTION_STRING") ?? "";
+            string tableName = "UserTokens";
+
+            // Get all tokens stored for this user
+            TableClient client = new(connectionString, tableName);
+            string filter = TableClient.CreateQueryFilter($"(PartitionKey eq {userId})");
+            List<TableEntity> userTokensSets = [];
+
+            foreach (TableEntity tokenSet in client.Query<TableEntity>(filter))
+            {
+                userTokensSets.Add(tokenSet);
+            }
+
+            bool foundValidToken = false;
+            for (int i = 0; i < userTokensSets.Count && !foundValidToken; i++)
+            {
+                TableEntity curTokenSet = userTokensSets[i];
+                string? curPartitionKey = curTokenSet["PartitionKey"].ToString();
+                string? curLogicToken = curTokenSet["LogicToken"].ToString();
+                string? curDbToken = curTokenSet["DbToken"].ToString();
+                if (curPartitionKey == userId && curLogicToken == logicToken && curDbToken == dbToken)
+                {
+                    foundValidToken = true;
+                }
+            }
+            if (!foundValidToken)
+            {
+                return (true, "Tokens do not match");
+            }
+            return (false, "Tokens match");
+        }
+    
+ }
+
+}

--- a/Logic/src/Shared/AzureTableService.cs
+++ b/Logic/src/Shared/AzureTableService.cs
@@ -43,7 +43,7 @@ namespace GoRideShare
             }
             if (!foundValidToken)
             {
-                return (true, "Tokens do not match");
+                return (true, "Tokens do not match, please sign in again!");
             }
             return (false, "Tokens match");
         }

--- a/Logic/src/Shared/HttpRequestHandler.cs
+++ b/Logic/src/Shared/HttpRequestHandler.cs
@@ -1,9 +1,4 @@
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.Functions.Worker;
-using Microsoft.Extensions.Logging;
 using System.Text;
-using System.Text.Json;
-using Microsoft.AspNetCore.Http;
 using System.Net.Http.Headers;
 
 namespace GoRideShare

--- a/Logic/src/Shared/IAzureTableService.cs
+++ b/Logic/src/Shared/IAzureTableService.cs
@@ -1,0 +1,8 @@
+namespace GoRideShare
+{
+    public interface IAzureTableService
+    {
+        (bool, string) VerifyUserTokens(string endpoint, string? db_token, string userId);
+    }
+
+}

--- a/Logic/src/Shared/IHttpRequestHandler.cs
+++ b/Logic/src/Shared/IHttpRequestHandler.cs
@@ -1,11 +1,3 @@
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.Functions.Worker;
-using Microsoft.Extensions.Logging;
-using System.Text;
-using System.Text.Json;
-using Microsoft.AspNetCore.Http;
-using System.Net.Http.Headers;
-
 namespace GoRideShare
 {
     public interface IHttpRequestHandler

--- a/Logic/src/Shared/Program.cs
+++ b/Logic/src/Shared/Program.cs
@@ -9,6 +9,7 @@ var host = new HostBuilder()
         services.AddApplicationInsightsTelemetryWorkerService();
         services.ConfigureFunctionsApplicationInsights();
         services.AddScoped<IHttpRequestHandler, HttpRequestHandler>();
+        services.AddSingleton<Utilities>();
     })
     .Build();
 

--- a/Logic/src/Shared/Program.cs
+++ b/Logic/src/Shared/Program.cs
@@ -9,6 +9,7 @@ var host = new HostBuilder()
         services.AddApplicationInsightsTelemetryWorkerService();
         services.ConfigureFunctionsApplicationInsights();
         services.AddScoped<IHttpRequestHandler, HttpRequestHandler>();
+        services.AddSingleton<IAzureTableService, AzureTableService>();
         services.AddSingleton<Utilities>();
     })
     .Build();

--- a/Logic/src/Shared/Utilities.cs
+++ b/Logic/src/Shared/Utilities.cs
@@ -1,16 +1,21 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.Functions.Worker.Http;
-using Azure.Data.Tables;
-using Microsoft.Extensions.Logging;
 
 namespace GoRideShare
 {
-    public static class Utilities
+    public class Utilities
     {
+
+        private readonly IAzureTableService _azureTableService;
+
+        public Utilities(IAzureTableService azureTableService)
+        {
+            _azureTableService = azureTableService;
+        }
+
         // Method that validates headers, outputs the userID and dbToken, and verifies that the tokens are matching 
         // returns exception if headers missing or tokens mismatch, null if all is good
-        public static IActionResult? ValidateHeadersAndTokens(IHeaderDictionary headers, out string userId, out string dbToken)
+        public IActionResult? ValidateHeadersAndTokens(IHeaderDictionary headers, out string userId, out string dbToken)
         {
             // Verify headers
             userId = string.Empty;
@@ -34,36 +39,12 @@ namespace GoRideShare
             string logicToken = logicTokenValue.ToString().Replace("Bearer ", "");
 
             // Verify tokens
-            string connectionString = Environment.GetEnvironmentVariable("USER_TOKENS_TABLE_CONNECTION_STRING") ?? "";
-            string tableName = "UserTokens";
-
-            // Get all tokens stored for this user
-            TableClient client = new(connectionString, tableName);
-            string filter = TableClient.CreateQueryFilter($"(PartitionKey eq {userId})");
-            List<TableEntity> userTokensSets = [];
-
-            foreach (TableEntity tokenSet in client.Query<TableEntity>(filter))
+            var (invalid, errorMessage) = _azureTableService.VerifyUserTokens(logicToken, userId, dbToken);
+            if (invalid)
             {
-                userTokensSets.Add(tokenSet);
+                return new UnauthorizedObjectResult(errorMessage);
             }
 
-            bool foundValidToken = false;
-            for (int i = 0; i < userTokensSets.Count && !foundValidToken; i++)
-            {
-                TableEntity curTokenSet = userTokensSets[i];
-                string? curPartitionKey = curTokenSet["PartitionKey"].ToString();
-                string? curLogicToken = curTokenSet["LogicToken"].ToString();
-                string? curDbToken = curTokenSet["DbToken"].ToString();
-                if (curPartitionKey == userId && curLogicToken == logicToken && curDbToken == dbToken)
-                {
-                    foundValidToken = true;
-                }
-            }
-
-            if (!foundValidToken)
-            {
-                return new UnauthorizedObjectResult("Tokens do not match");
-            }
             return null; // All headers are valid
         }
     }

--- a/Logic/src/Shared/Utilities.cs
+++ b/Logic/src/Shared/Utilities.cs
@@ -10,7 +10,7 @@ namespace GoRideShare
     {
         // Method that validates headers, outputs the userID and dbToken, and verifies that the tokens are matching 
         // returns exception if headers missing or tokens mismatch, null if all is good
-        public static IActionResult? ValidateHeaders(IHeaderDictionary headers, out string userId, out string dbToken)
+        public static IActionResult? ValidateHeadersAndTokens(IHeaderDictionary headers, out string userId, out string dbToken)
         {
             // Verify headers
             userId = string.Empty;

--- a/Logic/src/Shared/Utilities.cs
+++ b/Logic/src/Shared/Utilities.cs
@@ -1,18 +1,20 @@
-using System.Configuration;
-using System.Text.Json.Serialization;
-using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker.Http;
+using Azure.Data.Tables;
+using Microsoft.Extensions.Logging;
 
 namespace GoRideShare
 {
     public static class Utilities
     {
-        // Method that validates headers, outputs the userID and db_token, returns exception if headers  missing, null if headers are good
-        public static IActionResult? ValidateHeaders(IHeaderDictionary headers, out string userId, out string db_token)
+        // Method that validates headers, outputs the userID and dbToken, and verifies that the tokens are matching 
+        // returns exception if headers missing or tokens mismatch, null if all is good
+        public static IActionResult? ValidateHeaders(IHeaderDictionary headers, out string userId, out string dbToken)
         {
+            // Verify headers
             userId = string.Empty;
-            db_token = string.Empty;
+            dbToken = string.Empty;
 
             // Check for X-User-ID  and X-db_token headers
             if (!headers.TryGetValue("X-User-ID", out var userIdValue))
@@ -25,9 +27,44 @@ namespace GoRideShare
             {
                 return new BadRequestObjectResult("Missing the following header: 'X-Db-Token'.");
             }
-            db_token = db_tokenValue.ToString();
+            dbToken = db_tokenValue.ToString();
 
+            // Authorization is guarteed to be a header, otherwise Azure would not let this be called
+            headers.TryGetValue("Authorization", out var logicTokenValue);
+            string logicToken = logicTokenValue.ToString().Replace("Bearer ", "");
+
+            // Verify tokens
+            string connectionString = Environment.GetEnvironmentVariable("USER_TOKENS_TABLE_CONNECTION_STRING") ?? "";
+            string tableName = "UserTokens";
+
+            // Get all tokens stored for this user
+            TableClient client = new(connectionString, tableName);
+            string filter = TableClient.CreateQueryFilter($"(PartitionKey eq {userId})");
+            List<TableEntity> userTokensSets = [];
+
+            foreach (TableEntity tokenSet in client.Query<TableEntity>(filter))
+            {
+                userTokensSets.Add(tokenSet);
+            }
+
+            bool foundValidToken = false;
+            for (int i = 0; i < userTokensSets.Count && !foundValidToken; i++)
+            {
+                TableEntity curTokenSet = userTokensSets[i];
+                string? curPartitionKey = curTokenSet["PartitionKey"].ToString();
+                string? curLogicToken = curTokenSet["LogicToken"].ToString();
+                string? curDbToken = curTokenSet["DbToken"].ToString();
+                if (curPartitionKey == userId && curLogicToken == logicToken && curDbToken == dbToken)
+                {
+                    foundValidToken = true;
+                }
+            }
+
+            if (!foundValidToken)
+            {
+                return new UnauthorizedObjectResult("Tokens do not match");
+            }
             return null; // All headers are valid
         }
     }
-}
+} 

--- a/Logic/src/Users/EditUser.cs
+++ b/Logic/src/Users/EditUser.cs
@@ -27,7 +27,7 @@ namespace GoRideShare
         public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "patch", Route = "Users")] HttpRequest req)
         {
             // If validation result is not null, return the bad request result
-            var validationResult = Utilities.ValidateHeaders(req.Headers, out string userId, out string db_token);
+            var validationResult = Utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
             if (validationResult != null)
             {
                 return validationResult;

--- a/Logic/src/Users/EditUser.cs
+++ b/Logic/src/Users/EditUser.cs
@@ -15,11 +15,13 @@ namespace GoRideShare
         private readonly ILogger<EditUser> _logger;
         // Base URL for the API (retrieved from environment variables)
         private readonly string? _baseApiUrl;
+        private readonly Utilities _utilities;
 
-        public EditUser(ILogger<EditUser> logger, IHttpRequestHandler httpRequestHandler)
+        public EditUser(ILogger<EditUser> logger, IHttpRequestHandler httpRequestHandler, Utilities utilities)
         {
-             _httpRequestHandler = httpRequestHandler;
+            _httpRequestHandler = httpRequestHandler;
             _logger = logger;
+            _utilities = utilities;
             _baseApiUrl = Environment.GetEnvironmentVariable("BASE_API_URL");
         }
 
@@ -27,7 +29,7 @@ namespace GoRideShare
         public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "patch", Route = "Users")] HttpRequest req)
         {
             // If validation result is not null, return the bad request result
-            var validationResult = Utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
+            var validationResult = _utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
             if (validationResult != null)
             {
                 return validationResult;

--- a/Logic/src/Users/GetUser.cs
+++ b/Logic/src/Users/GetUser.cs
@@ -13,10 +13,12 @@ namespace GoRideShare
         private readonly ILogger<GetUser> _logger;
         private readonly IHttpRequestHandler _httpRequestHandler;
         private readonly string? _baseApiUrl;
+        private readonly Utilities _utilities;
 
-        public GetUser(ILogger<GetUser> logger, IHttpRequestHandler httpRequestHandler)
+        public GetUser(ILogger<GetUser> logger, IHttpRequestHandler httpRequestHandler, Utilities utilities)
         {
             _logger = logger;
+            _utilities = utilities;
             _httpRequestHandler = httpRequestHandler;
             _baseApiUrl = Environment.GetEnvironmentVariable("BASE_API_URL");
         }
@@ -26,7 +28,7 @@ namespace GoRideShare
         public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "Users/{user_id}")] HttpRequest req, string? user_id)
         {
             // If validation result is not null, return the bad request result
-            var validationResult = Utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
+            var validationResult = _utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
             if (validationResult != null)
             {
                 return validationResult;

--- a/Logic/src/Users/GetUser.cs
+++ b/Logic/src/Users/GetUser.cs
@@ -26,7 +26,7 @@ namespace GoRideShare
         public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "Users/{user_id}")] HttpRequest req, string? user_id)
         {
             // If validation result is not null, return the bad request result
-            var validationResult = Utilities.ValidateHeaders(req.Headers, out string userId, out string db_token);
+            var validationResult = Utilities.ValidateHeadersAndTokens(req.Headers, out string userId, out string db_token);
             if (validationResult != null)
             {
                 return validationResult;


### PR DESCRIPTION
Whenever a user logs in or creates an account, the token set (UserId, Logic token and Db token) is stored in Azure Table Storage. Only two token sets are stored. The oldest one is replaced by the new one at login/sign up. 

The validation happens inside of `ValidateHeaders` method. If the tokens do not match, unauthorized response code is given with message "Tokens do not match".

Tested locally, but would need to be tested online too. 